### PR TITLE
ryujinx fixes

### DIFF
--- a/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
+++ b/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
@@ -35,8 +35,8 @@ class RyujinxMainlineGenerator(Generator):
         if not path.isdir(batoceraFiles.CONF + "/Ryujinx/system"):
             os.mkdir(batoceraFiles.CONF + "/Ryujinx/system")
 
-        copyfile(batoceraFiles.BIOS + "/switch/prod.keys", batoceraFiles.CONF + "/Ryujinx/system/prod.keys")
-        copyfile(batoceraFiles.BIOS + "/switch/title.keys", batoceraFiles.CONF + "/Ryujinx/system/title.keys")
+        #copyfile(batoceraFiles.BIOS + "/switch/prod.keys", batoceraFiles.CONF + "/Ryujinx/system/prod.keys")
+        #copyfile(batoceraFiles.BIOS + "/switch/title.keys", batoceraFiles.CONF + "/Ryujinx/system/title.keys")
 
         RyujinxConfig = batoceraFiles.CONF + '/Ryujinx/Config.json'
         RyujinxHome = batoceraFiles.CONF

--- a/system/switch/extra/batocera-switch-updater.sh
+++ b/system/switch/extra/batocera-switch-updater.sh
@@ -411,7 +411,7 @@ echo 'rm -rf /userdata/system/.config/Ryujinx0' >> $startup
 echo 'ln -s /userdata/system/configs/Ryujinx /userdata/system/.config/Ryujinx 2>/dev/null' >> $startup
 echo 'mv /userdata/system/configs/Ryujinx/system /userdata/system/configs/Ryujinx/system0 2>/dev/null' >> $startup
 echo 'cp -rL /userdata/system/configs/Ryujinx/system0/* /userdata/bios/switch/ 2>/dev/null' >> $startup
-echo 'rm -rf /userdata/system/configs/Ryujinx/system0 2>/dev/null' >> $startup
+echo 'rm -rf /userdata/system/configs/Ryujinx/system0 2>/dev/null; rm /userdata/system/configs/Ryujinx/Ryujinx' >> $startup
 echo 'ln -s /userdata/bios/switch /userdata/system/configs/Ryujinx/system 2>/dev/null' >> $startup
 dos2unix $startup
 chmod a+x $startup
@@ -469,7 +469,7 @@ echo 'rm -rf /userdata/system/.config/Ryujinx0' >> $startup
 echo 'ln -s /userdata/system/configs/Ryujinx /userdata/system/.config/Ryujinx 2>/dev/null' >> $startup
 echo 'mv /userdata/system/configs/Ryujinx/system /userdata/system/configs/Ryujinx/system0 2>/dev/null' >> $startup
 echo 'cp -rL /userdata/system/configs/Ryujinx/system0/* /userdata/bios/switch/ 2>/dev/null' >> $startup
-echo 'rm -rf /userdata/system/configs/Ryujinx/system0 2>/dev/null' >> $startup
+echo 'rm -rf /userdata/system/configs/Ryujinx/system0 2>/dev/null; rm /userdata/system/configs/Ryujinx/Ryujinx' >> $startup
 echo 'ln -s /userdata/bios/switch /userdata/system/configs/Ryujinx/system 2>/dev/null' >> $startup
 dos2unix $startup
 chmod a+x $startup


### PR DESCRIPTION
+remove looped ryu symlink
+remove keyscopy from ryu generator as ryu's system(keys) folder now links to /bios/switch 