### PR TITLE
+ bioslink for yuzu&ryujinx

### DIFF
--- a/system/switch/configgen/generators/yuzu/yuzuMainlineGenerator.py
+++ b/system/switch/configgen/generators/yuzu/yuzuMainlineGenerator.py
@@ -87,8 +87,8 @@ class YuzuMainlineGenerator(Generator):
         if not os.path.exists("/userdata/system/.cache/yuzu/game_list"):
             st = os.symlink("/userdata/saves/yuzu","/userdata/system/.cache/yuzu/game_list")
 
-        copyfile(batoceraFiles.BIOS + "/switch/prod.keys", batoceraFiles.CONF + "/yuzu/keys/prod.keys")
-        copyfile(batoceraFiles.BIOS + "/switch/title.keys", batoceraFiles.CONF + "/yuzu/keys/title.keys")
+        #copyfile(batoceraFiles.BIOS + "/switch/prod.keys", batoceraFiles.CONF + "/yuzu/keys/prod.keys")
+        #copyfile(batoceraFiles.BIOS + "/switch/title.keys", batoceraFiles.CONF + "/yuzu/keys/title.keys")
 
         yuzuConfig = batoceraFiles.CONF + '/yuzu/qt-config.ini'
         beforeyuzuConfig = batoceraFiles.CONF + '/yuzu/before-qt-config.ini'

--- a/system/switch/extra/batocera-switch-updater.sh
+++ b/system/switch/extra/batocera-switch-updater.sh
@@ -110,10 +110,10 @@ generate-shortcut-launcher 'yuzuEA' 'yuzuea'
 generate-shortcut-launcher 'Ryujinx' 'ryujinx'
 generate-shortcut-launcher 'Ryujinx-Avalonia' 'ryujinx-avalonia'
 # -------------------------------------------------------------------
-# PREPARE STARTUP FILE
+# PREPARE BATOCERA-SWITCH-STARTUP FILE
 # -------------------------------------------------------------------
 startup=/userdata/system/switch/extra/batocera-switch-startup
-rm -rf $startup
+rm -rf $startup 2>/dev/null
 echo '#!/bin/bash' >> $startup 
 echo 'extra=/userdata/system/switch/extra' >> $startup
 echo 'cp $extra/batocera-switch-lib* /lib/ 2>/dev/null' >> $startup
@@ -121,8 +121,29 @@ echo 'cp $extra/lib* /lib/ 2>/dev/null' >> $startup
 echo 'cp $extra/*.desktop /usr/share/applications/ 2>/dev/null' >> $startup
 echo '/userdata/system/switch/extra/ryujinx/startup 2>/dev/null' >> $startup
 echo '/userdata/system/switch/extra/ryujinxavalonia/startup 2>/dev/null' >> $startup
-dos2unix $startup
-chmod a+x $startup
+# link ryujinx config folders
+echo 'mkdir /userdata/system/configs/Ryujinx 2>/dev/null' >> $startup
+echo 'mv /userdata/system/configs/Ryujinx /userdata/system/configs/Ryujinx_tmp 2>/dev/null' >> $startup
+echo 'cp -rL /userdata/system/.config/Ryujinx/* /userdata/configs/Ryujinx_tmp 2>/dev/null' >> $startup
+echo 'rm -rf /userdata/system/.config/Ryujinx' >> $startup
+echo 'mv /userdata/system/configs/Ryujinx_tmp /userdata/system/configs/Ryujinx 2>/dev/null' >> $startup
+echo 'ln -s /userdata/system/configs/Ryujinx /userdata/system/.config/Ryujinx 2>/dev/null' >> $startup
+echo 'rm /userdata/system/configs/Ryujinx/Ryujinx 2>/dev/null' >> $startup
+# link yuzu and ryujinx keys folders to bios/switch 
+echo 'cp -rL /userdata/system/configs/yuzu/keys/* /userdata/bios/switch/ 2>/dev/null' >> $startup
+echo 'cp -rL /userdata/system/configs/Ryujinx/system/* /userdata/bios/switch/ 2>/dev/null' >> $startup
+echo 'mkdir -p /userdata/system/configs/yuzu 2>/dev/null' >> $startup
+echo 'mkdir -p /userdata/system/configs/Ryujinx 2>/dev/null' >> $startup
+echo 'mv /userdata/bios/switch /userdata/bios/switch_tmp 2>/dev/null' >> $startup
+echo 'rm -rf /userdata/system/configs/yuzu/keys 2>/dev/null' >> $startup
+echo 'rm -rf /userdata/system/configs/Ryujinx/system 2>/dev/null' >> $startup
+echo 'mv /userdata/bios/switch_tmp /userdata/bios/switch 2>/dev/null' >> $startup
+echo 'ln -s /userdata/bios/switch /userdata/system/configs/yuzu/keys 2>/dev/null' >> $startup
+echo 'ln -s /userdata/bios/switch /userdata/system/configs/Ryujinx/system 2>/dev/null' >> $startup
+dos2unix $startup 
+chmod a+x $startup 
+# & run startup immediatelly: 
+/userdata/system/switch/extra/batocera-switch-startup 
 # -------------------------------------------------------------------
 # ADD TO BATOCERA AUTOSTART > /USERDATA/SYSTEM/CUSTOM.SH 
 # -------------------------------------------------------------------
@@ -404,15 +425,6 @@ echo 'dependencies=/userdata/system/switch/extra/'$emu'/dependencies' >> $startu
 echo 'L=1; while [[ "$L" -le "$(cat $dependencies | wc -l)" ]]; do' >> $startup
 echo 'lib=$(cat $dependencies | sed ""$L"q;d")' >> $startup
 echo 'rm  /lib/$lib 2>/dev/null; ln -s /userdata/system/switch/extra/'$emu'/$lib /lib/$lib 2>/dev/null; ((L++)); done' >> $startup
-echo 'mkdir /userdata/system/configs/Ryujinx 2>/dev/null' >> $startup
-echo 'mv /userdata/.config/Ryujinx /userdata/.config/Ryujinx0 2>/dev/null' >> $startup
-echo 'cp -rL /userdata/system/.config/Ryujinx0/* /userdata/configs/Ryujinx/ 2>/dev/null' >> $startup
-echo 'rm -rf /userdata/system/.config/Ryujinx0' >> $startup
-echo 'ln -s /userdata/system/configs/Ryujinx /userdata/system/.config/Ryujinx 2>/dev/null' >> $startup
-echo 'mv /userdata/system/configs/Ryujinx/system /userdata/system/configs/Ryujinx/system0 2>/dev/null' >> $startup
-echo 'cp -rL /userdata/system/configs/Ryujinx/system0/* /userdata/bios/switch/ 2>/dev/null' >> $startup
-echo 'rm -rf /userdata/system/configs/Ryujinx/system0 2>/dev/null; rm /userdata/system/configs/Ryujinx/Ryujinx' >> $startup
-echo 'ln -s /userdata/bios/switch /userdata/system/configs/Ryujinx/system 2>/dev/null' >> $startup
 dos2unix $startup
 chmod a+x $startup
 $extra/$emu/startup 2>/dev/null
@@ -462,15 +474,6 @@ echo 'dependencies=/userdata/system/switch/extra/'$emu'/dependencies' >> $startu
 echo 'L=1; while [[ "$L" -le "$(cat $dependencies | wc -l)" ]]; do' >> $startup
 echo 'lib=$(cat $dependencies | sed ""$L"q;d")' >> $startup
 echo 'rm  /lib/$lib 2>/dev/null; ln -s /userdata/system/switch/extra/'$emu'/$lib /lib/$lib 2>/dev/null; ((L++)); done' >> $startup
-echo 'mkdir /userdata/system/configs/Ryujinx 2>/dev/null' >> $startup
-echo 'mv /userdata/.config/Ryujinx /userdata/.config/Ryujinx0 2>/dev/null' >> $startup
-echo 'cp -rL /userdata/system/.config/Ryujinx0/* /userdata/configs/Ryujinx/ 2>/dev/null' >> $startup
-echo 'rm -rf /userdata/system/.config/Ryujinx0' >> $startup
-echo 'ln -s /userdata/system/configs/Ryujinx /userdata/system/.config/Ryujinx 2>/dev/null' >> $startup
-echo 'mv /userdata/system/configs/Ryujinx/system /userdata/system/configs/Ryujinx/system0 2>/dev/null' >> $startup
-echo 'cp -rL /userdata/system/configs/Ryujinx/system0/* /userdata/bios/switch/ 2>/dev/null' >> $startup
-echo 'rm -rf /userdata/system/configs/Ryujinx/system0 2>/dev/null; rm /userdata/system/configs/Ryujinx/Ryujinx' >> $startup
-echo 'ln -s /userdata/bios/switch /userdata/system/configs/Ryujinx/system 2>/dev/null' >> $startup
 dos2unix $startup
 chmod a+x $startup
 $extra/$emu/startup 2>/dev/null


### PR DESCRIPTION
+ both emus now linked directly to bios/switch after running updater & generating batocera-switch-startup 
+ moved ryu+ava configlinkers into main startup linker 