### PR TITLE
+moving fw_linker to rsync

### DIFF
--- a/system/switch/extra/batocera-switch-sshupdater.sh
+++ b/system/switch/extra/batocera-switch-sshupdater.sh
@@ -193,28 +193,23 @@ echo 'mkdir -p /userdata/system/configs/yuzu 2>/dev/null' >> $startup
 echo 'mkdir -p /userdata/system/configs/Ryujinx 2>/dev/null' >> $startup
 echo 'ln -s /userdata/bios/switch /userdata/system/configs/yuzu/keys 2>/dev/null' >> $startup
 echo 'ln -s /userdata/bios/switch /userdata/system/configs/Ryujinx/system 2>/dev/null' >> $startup
-#\ link yuzu and ryujinx firmware folders to bios/switch/firmware
-echo '#\ link yuzu and ryujinx firmware folders to bios/switch/firmware' >> $startup
+#\ rsync ryujinx+yuzu firmware folders with bios/switch/firmware
+echo '#\ rsync ryujinx+yuzu firmware folders with bios/switch/firmware' >> $startup
 echo 'ff=/userdata/bios/switch/firmware' >> $startup
-echo 'ft=/userdata/bios/switch/.firmware' >> $startup
+echo 'ft=/userdata/bios/switch/_firmware_' >> $startup
 echo 'fr=/userdata/system/configs/Ryujinx/bis/system/Contents/registered' >> $startup
 echo 'fy=/userdata/system/configs/yuzu/nand/system/Contents/registered' >> $startup
+echo 'rm $fr 2>/dev/null' >> $startup
+echo 'rm $fy 2>/dev/null' >> $startup
 echo 'mkdir -p $ff 2>/dev/null' >> $startup
+echo 'mkdir -p $ft 2>/dev/null' >> $startup
 echo 'mkdir -p $fr 2>/dev/null' >> $startup
 echo 'mkdir -p $fy 2>/dev/null' >> $startup
-echo "sff=\$(du -s \$ff | awk '{print \$1}')" >> $startup
-echo "sfr=\$(du -s \$fr | awk '{print \$1}')" >> $startup
-echo "sfy=\$(du -s \$fy | awk '{print \$1}')" >> $startup
-echo 'if [[ -d "$fy" ]] && [[ "$sfy" > "0" ]]; then rm -rf $ff/* 2>/dev/null; chmod 777 $fy/*; cp -rL $fy/* $ff/ 2>/dev/null; fi' >> $startup
-echo 'if [[ -d "$fr" ]] && [[ "$sfr" > "0" ]]; then rm -rf $ff/* 2>/dev/null; chmod 777 $fr/*; cp -rL $fr/* $ff/ 2>/dev/null; fi' >> $startup
+echo 'rsync -au $ff/ $fr/' >> $startup
+echo 'rsync -au $fr/ $ff/' >> $startup
+echo 'rsync -au $ff/ $fy/' >> $startup
+echo 'rsync -au $fy/ $ff/' >> $startup
 echo 'rm -rf $ft 2>/dev/null' >> $startup
-echo 'mv $ff $ft 2>/dev/null' >> $startup
-echo 'rm -rf $fr 2>/dev/null' >> $startup
-echo 'rm -rf $fy 2>/dev/null' >> $startup
-echo 'mv $ft $ff 2>/dev/null' >> $startup
-echo 'ln -s $ff $fr 2>/dev/null' >> $startup
-echo 'ln -s $ff $fy 2>/dev/null' >> $startup
-echo 'chmod 777 $ff/* 2>/dev/null' >> $startup
 echo '#/' >> $startup
 dos2unix $startup 
 chmod a+x $startup 

--- a/system/switch/extra/batocera-switch-sshupdater.sh
+++ b/system/switch/extra/batocera-switch-sshupdater.sh
@@ -195,6 +195,7 @@ echo 'ln -s /userdata/bios/switch /userdata/system/configs/yuzu/keys 2>/dev/null
 echo 'ln -s /userdata/bios/switch /userdata/system/configs/Ryujinx/system 2>/dev/null' >> $startup
 #\ rsync ryujinx+yuzu firmware folders with bios/switch/firmware
 echo '#\ rsync ryujinx+yuzu firmware folders with bios/switch/firmware' >> $startup
+echo 'rm -rf /userdata/bios/switch/.firmware 2>/dev/null' >> $startup
 echo 'ff=/userdata/bios/switch/firmware' >> $startup
 echo 'ft=/userdata/bios/switch/_firmware_' >> $startup
 echo 'fr=/userdata/system/configs/Ryujinx/bis/system/Contents/registered' >> $startup

--- a/system/switch/extra/batocera-switch-updater.sh
+++ b/system/switch/extra/batocera-switch-updater.sh
@@ -193,29 +193,23 @@ echo 'mkdir -p /userdata/system/configs/yuzu 2>/dev/null' >> $startup
 echo 'mkdir -p /userdata/system/configs/Ryujinx 2>/dev/null' >> $startup
 echo 'ln -s /userdata/bios/switch /userdata/system/configs/yuzu/keys 2>/dev/null' >> $startup
 echo 'ln -s /userdata/bios/switch /userdata/system/configs/Ryujinx/system 2>/dev/null' >> $startup
-#\ link yuzu and ryujinx firmware folders to bios/switch/firmware
-echo '#\ link yuzu and ryujinx firmware folders to bios/switch/firmware' >> $startup
+#\ rsync ryujinx+yuzu firmware folders with bios/switch/firmware
+echo '#\ rsync ryujinx+yuzu firmware folders with bios/switch/firmware' >> $startup
 echo 'ff=/userdata/bios/switch/firmware' >> $startup
 echo 'ft=/userdata/bios/switch/_firmware_' >> $startup
 echo 'fr=/userdata/system/configs/Ryujinx/bis/system/Contents/registered' >> $startup
 echo 'fy=/userdata/system/configs/yuzu/nand/system/Contents/registered' >> $startup
+echo 'rm $fr 2>/dev/null' >> $startup
+echo 'rm $fy 2>/dev/null' >> $startup
 echo 'mkdir -p $ff 2>/dev/null' >> $startup
 echo 'mkdir -p $ft 2>/dev/null' >> $startup
 echo 'mkdir -p $fr 2>/dev/null' >> $startup
 echo 'mkdir -p $fy 2>/dev/null' >> $startup
-echo "sff=\$(du -s \$ff | awk '{print \$1}')" >> $startup
-echo "sft=\$(du -s \$ft | awk '{print \$1}')" >> $startup
-echo "sfr=\$(du -s \$fr | awk '{print \$1}')" >> $startup
-echo "sfy=\$(du -s \$fy | awk '{print \$1}')" >> $startup
-echo 'if [[ -d "$fy" ]] && [[ "$sfy" > "$sff" ]]; then cp -rL $fy/* $ft/ 2>/dev/null; fi' >> $startup
-echo 'if [[ -d "$fr" ]] && [[ "$sfr" > "$sff" ]]; then cp -rL $fr/* $ft/ 2>/dev/null; fi' >> $startup
-echo 'rm -rf $fr 2>/dev/null' >> $startup
-echo 'rm -rf $fy 2>/dev/null' >> $startup
-echo "sff=\$(du -s \$ff | awk '{print \$1}')" >> $startup
-echo "sft=\$(du -s \$ft | awk '{print \$1}')" >> $startup
-echo 'if [[ "$sft" > "$sff" ]]; then cp -rL $ft/* $ff/* 2>/dev/null; fi' >> $startup
-echo 'ln -s $ff $fr 2>/dev/null' >> $startup
-echo 'ln -s $ff $fy 2>/dev/null' >> $startup
+echo 'rsync -au $ff/ $fr/' >> $startup
+echo 'rsync -au $fr/ $ff/' >> $startup
+echo 'rsync -au $ff/ $fy/' >> $startup
+echo 'rsync -au $fy/ $ff/' >> $startup
+echo 'rm -rf $ft 2>/dev/null' >> $startup
 echo '#/' >> $startup
 dos2unix $startup 
 chmod a+x $startup 

--- a/system/switch/extra/batocera-switch-updater.sh
+++ b/system/switch/extra/batocera-switch-updater.sh
@@ -195,6 +195,7 @@ echo 'ln -s /userdata/bios/switch /userdata/system/configs/yuzu/keys 2>/dev/null
 echo 'ln -s /userdata/bios/switch /userdata/system/configs/Ryujinx/system 2>/dev/null' >> $startup
 #\ rsync ryujinx+yuzu firmware folders with bios/switch/firmware
 echo '#\ rsync ryujinx+yuzu firmware folders with bios/switch/firmware' >> $startup
+echo 'rm -rf /userdata/bios/switch/.firmware 2>/dev/null' >> $startup
 echo 'ff=/userdata/bios/switch/firmware' >> $startup
 echo 'ft=/userdata/bios/switch/_firmware_' >> $startup
 echo 'fr=/userdata/system/configs/Ryujinx/bis/system/Contents/registered' >> $startup


### PR DESCRIPTION
due to issues with symlinking firmware mainly:

1) requiring supported filesystem
2) issues with ryu 'installing from zip' (it'll stall on 'file exists' because it can't process symlink instead of directory)
3) for some users simply not working for whatever reason even though everything seems to be 100% ok

-> i'm removing fw symlinking and moving it to two-way rsync between /bios/switch/firmware and emulators folders - this way whatever is newer, be it manual unzip to bios/switch/firmware or manual install from ryujinx - fw files will get synced between folders/emulators

cons: size bloat (if compared to ln -s), but this is how it used to be previously and running switch emulation requires manyGBs anyway