### PR TITLE
add-powermode

### DIFF
--- a/system/configs/emulationstation/es_features_switch.cfg
+++ b/system/configs/emulationstation/es_features_switch.cfg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <features>
   <emulator name="yuzu-mainline">
+    <sharedFeature value="powermode" />
     <sharedFeature value="hud" />
     <sharedFeature value="hud_corner" />
     <feature name="AUTO CONTROLLER CONFIG" value="yuzu_auto_controller_config" description="Auto Controller Configuration Auto=On ">
@@ -222,6 +223,7 @@
     </feature>
   </emulator>
   <emulator name="yuzu-early-access">
+    <sharedFeature value="powermode" />
     <sharedFeature value="hud" />
     <sharedFeature value="hud_corner" />
     <feature name="AUTO CONTROLLER CONFIG" value="yuzu_auto_controller_config" description="Auto Controller Configuration Auto=On ">
@@ -443,6 +445,7 @@
     </feature>
   </emulator>
   <emulator name="ryujinx-continuous" features="padtokeyboard">
+    <sharedFeature value="powermode" />
     <sharedFeature value="hud" />
     <sharedFeature value="hud_corner" />
     <feature name="AUTO CONTROLLER CONFIG" value="ryu_auto_controller_config" description="Auto Controller Configuration Auto=On ">
@@ -599,6 +602,7 @@
     </feature>
   </emulator>
   <emulator name="ryujinx-avalonia" features="padtokeyboard">
+    <sharedFeature value="powermode" />
     <sharedFeature value="hud" />
     <sharedFeature value="hud_corner" />
     <feature name="AUTO CONTROLLER CONFIG" value="ryu_auto_controller_config" description="Auto Controller Configuration Auto=On ">
@@ -755,6 +759,7 @@
     </feature>
   </emulator>
   <emulator name="ryujinx-ldn" features="padtokeyboard">
+    <sharedFeature value="powermode" />
     <sharedFeature value="hud" />
     <sharedFeature value="hud_corner" />
     <feature name="AUTO CONTROLLER CONFIG" value="ryu_auto_controller_config" description="Auto Controller Configuration Auto=On ">


### PR DESCRIPTION
Adds new powermode feature  to switch es settings. Note this feature is only implemented in Batocera V39 and later.