### PR TITLE
do not erase the prefered gpu defined by the user

### DIFF
--- a/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
+++ b/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
@@ -642,7 +642,9 @@ class RyujinxMainlineGenerator(Generator):
         else:
             data['graphics_backend'] = 'Vulkan'
 
-        data['preferred_gpu'] = ""
+        # this erases the user manual configuration.
+        # It's problematic in case of hybrid laptop as it may always default to the igpu instead of the dgpu
+        # data['preferred_gpu'] = ""
 
         with open(batoceraFiles.CONF + '/Ryujinx/BeforeRyu.json', "w") as outfile:
             outfile.write(json.dumps(data, indent=2))


### PR DESCRIPTION
I was getting mad because I changed the gpu from the igpu to my dgpu through ryujinx avalonia interface, but each time I launched a game, it reverted to my igpu, resulting in terrible performances.
It's better to not overwrite this setting.