### PR TITLE
remove forced version number

### DIFF
--- a/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
+++ b/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
@@ -101,14 +101,6 @@ class RyujinxMainlineGenerator(Generator):
                 data = json.load(read_file)
         else:
                 data = {}
-
-        if system.config['emulator'] == 'ryujinx-avalonia':
-            data['version'] = 42  #Avalonia Version needs to see 38
-        else:
-            if(ryu_version == 382):
-                data['version'] = 40  #1.1.382 version
-            else:
-                data['version'] = 47 #1.1.924 version
         
         data['enable_file_log'] = bool('true')
         data['backend_threading'] = 'Auto'

--- a/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
+++ b/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
@@ -101,7 +101,24 @@ class RyujinxMainlineGenerator(Generator):
                 data = json.load(read_file)
         else:
                 data = {}
-        
+
+        if system.config['emulator'] == 'ryujinx-avalonia':
+            if ryu_version >= 1215:
+                data['version'] = 49
+            elif ryu_version >= 924:
+                data['version'] = 47
+            else:
+                data['version'] = 42
+        else:
+            if ryu_version >= 1215:
+                data['version'] = 49
+            elif ryu_version >= 924:
+                data['version'] = 47
+            elif ryu_version > 382:
+                data['version'] = 42
+            else:
+                data['version'] = 40
+                
         data['enable_file_log'] = bool('true')
         data['backend_threading'] = 'Auto'
 


### PR DESCRIPTION
As this version (42) is too low, if the user sets the upscaling to "FSR", it will go back to "Bilinear" because I suppose that "FSR" was not supported in old versions of the config file.

I don't think there's an advantage in keeping an old version number which erases what the user sets in ryujinx.
But maybe there are some specific cases ? Or maybe, we don't need this anymore.

