### PR TITLE
custom res descriptions for Ryujinx

### DIFF
--- a/system/configs/emulationstation/es_features_switch.cfg
+++ b/system/configs/emulationstation/es_features_switch.cfg
@@ -523,36 +523,35 @@
       <choice name="2x (1440p/2160p)" value="2.0" />
       <choice name="3x (2160p/3240p)" value="3.0" />
       <choice name="4x (2880p/4320p)" value="4.0" />
-      <choice name="Custom 0.1x" value="0.1" />
-      <choice name="Custom 0.2x" value="0.2" />
-      <choice name="Custom 0.3x" value="0.3" />
-      <choice name="Custom 0.4x" value="0.4" />
-      <choice name="Custom 0.5x" value="0.5" />
-      <choice name="Custom 0.6x" value="0.6" />
-      <choice name="Custom 0.7x" value="0.7" />
-      <choice name="Custom 0.8x" value="0.8" />
-      <choice name="Custom 0.9x" value="0.9" />
-      <choice name="Custom 1.0x" value="1.0" />
-      <choice name="Custom 1.1x" value="1.1" />
-      <choice name="Custom 1.2x" value="1.2" />
-      <choice name="Custom 1.3x" value="1.3" />
-      <choice name="Custom 1.4x" value="1.4" />
-      <choice name="Custom 1.5x" value="1.5" />
-      <choice name="Custom 1.6x" value="1.6" />
-      <choice name="Custom 1.7x" value="1.7" />
-      <choice name="Custom 1.8x" value="1.8" />
-      <choice name="Custom 1.9x" value="1.9" />
-      <choice name="Custom 2.0x" value="2.0" />
-      <choice name="Custom 2.1x" value="2.1" />
-      <choice name="Custom 2.2x" value="2.2" />
-      <choice name="Custom 2.3x" value="2.3" />
-      <choice name="Custom 2.4x" value="2.4" />
-      <choice name="Custom 2.5x" value="2.5" />
-      <choice name="Custom 2.6x" value="2.6" />
-      <choice name="Custom 2.7x" value="2.7" />
-      <choice name="Custom 2.8x" value="2.8" />
-      <choice name="Custom 2.9x" value="2.9" />
-      <choice name="Custom 3.0x" value="3.0" />
+      <choice name="Custom 0.2x (144p/216p)" value="0.2" />
+      <choice name="Custom 0.3x (216p/324p)" value="0.3" />
+      <choice name="Custom 0.4x (288p/432p)" value="0.4" />
+      <choice name="Custom 0.5x (360p/540p)" value="0.5" />
+      <choice name="Custom 0.6x (432p/648p)" value="0.6" />
+      <choice name="Custom 0.7x (504p/756p)" value="0.7" />
+      <choice name="Custom 0.8x (576p/864p)" value="0.8" />
+      <choice name="Custom 0.9x (648p/972p)" value="0.9" />
+      <choice name="Custom 1.0x (720p/1080p)" value="1.0" />
+      <choice name="Custom 1.1x (792p/1188p)" value="1.1" />
+      <choice name="Custom 1.2x (864p/1296p)" value="1.2" />
+      <choice name="Custom 1.3x (936p/1404p)" value="1.3" />
+      <choice name="Custom 1.4x (1008p/1512p)" value="1.4" />
+      <choice name="Custom 1.5x (1080p/1620p)" value="1.5" />
+      <choice name="Custom 1.6x (1152p/1728p)" value="1.6" />
+      <choice name="Custom 1.7x (1224p/1836p)" value="1.7" />
+      <choice name="Custom 1.8x (1296p/1994p)" value="1.8" />
+      <choice name="Custom 1.9x (1368p/2052p)" value="1.9" />
+      <choice name="Custom 2.0x (1440p/2160p)" value="2.0" />
+      <choice name="Custom 2.1x (1512p/2268p)" value="2.1" />
+      <choice name="Custom 2.2x (1584p/2376p)" value="2.2" />
+      <choice name="Custom 2.3x (1656p/2484p)" value="2.3" />
+      <choice name="Custom 2.4x (1728p/2592p)" value="2.4" />
+      <choice name="Custom 2.5x (1800p/2700p)" value="2.5" />
+      <choice name="Custom 2.6x (1872p/2808p)" value="2.6" />
+      <choice name="Custom 2.7x (1944p/2916p)" value="2.7" />
+      <choice name="Custom 2.8x (2016p/3024p)" value="2.8" />
+      <choice name="Custom 2.9x (2088p/3132p)" value="2.9" />
+      <choice name="Custom 3.0x (2160p/3240p)" value="3.0" />
     </feature>
     <feature name="ASPECT RATIO" value="aspect_ratio" description="Aspect Ratio Auto=16:9">
       <choice name="4:3" value="Fixed4x3" />
@@ -720,36 +719,35 @@
       <choice name="2x (1440p/2160p)" value="2.0" />
       <choice name="3x (2160p/3240p)" value="3.0" />
       <choice name="4x (2880p/4320p)" value="4.0" />
-      <choice name="Custom 0.1x" value="0.1" />
-      <choice name="Custom 0.2x" value="0.2" />
-      <choice name="Custom 0.3x" value="0.3" />
-      <choice name="Custom 0.4x" value="0.4" />
-      <choice name="Custom 0.5x" value="0.5" />
-      <choice name="Custom 0.6x" value="0.6" />
-      <choice name="Custom 0.7x" value="0.7" />
-      <choice name="Custom 0.8x" value="0.8" />
-      <choice name="Custom 0.9x" value="0.9" />
-      <choice name="Custom 1.0x" value="1.0" />
-      <choice name="Custom 1.1x" value="1.1" />
-      <choice name="Custom 1.2x" value="1.2" />
-      <choice name="Custom 1.3x" value="1.3" />
-      <choice name="Custom 1.4x" value="1.4" />
-      <choice name="Custom 1.5x" value="1.5" />
-      <choice name="Custom 1.6x" value="1.6" />
-      <choice name="Custom 1.7x" value="1.7" />
-      <choice name="Custom 1.8x" value="1.8" />
-      <choice name="Custom 1.9x" value="1.9" />
-      <choice name="Custom 2.0x" value="2.0" />
-      <choice name="Custom 2.1x" value="2.1" />
-      <choice name="Custom 2.2x" value="2.2" />
-      <choice name="Custom 2.3x" value="2.3" />
-      <choice name="Custom 2.4x" value="2.4" />
-      <choice name="Custom 2.5x" value="2.5" />
-      <choice name="Custom 2.6x" value="2.6" />
-      <choice name="Custom 2.7x" value="2.7" />
-      <choice name="Custom 2.8x" value="2.8" />
-      <choice name="Custom 2.9x" value="2.9" />
-      <choice name="Custom 3.0x" value="3.0" />
+      <choice name="Custom 0.2x (144p/216p)" value="0.2" />
+      <choice name="Custom 0.3x (216p/324p)" value="0.3" />
+      <choice name="Custom 0.4x (288p/432p)" value="0.4" />
+      <choice name="Custom 0.5x (360p/540p)" value="0.5" />
+      <choice name="Custom 0.6x (432p/648p)" value="0.6" />
+      <choice name="Custom 0.7x (504p/756p)" value="0.7" />
+      <choice name="Custom 0.8x (576p/864p)" value="0.8" />
+      <choice name="Custom 0.9x (648p/972p)" value="0.9" />
+      <choice name="Custom 1.0x (720p/1080p)" value="1.0" />
+      <choice name="Custom 1.1x (792p/1188p)" value="1.1" />
+      <choice name="Custom 1.2x (864p/1296p)" value="1.2" />
+      <choice name="Custom 1.3x (936p/1404p)" value="1.3" />
+      <choice name="Custom 1.4x (1008p/1512p)" value="1.4" />
+      <choice name="Custom 1.5x (1080p/1620p)" value="1.5" />
+      <choice name="Custom 1.6x (1152p/1728p)" value="1.6" />
+      <choice name="Custom 1.7x (1224p/1836p)" value="1.7" />
+      <choice name="Custom 1.8x (1296p/1994p)" value="1.8" />
+      <choice name="Custom 1.9x (1368p/2052p)" value="1.9" />
+      <choice name="Custom 2.0x (1440p/2160p)" value="2.0" />
+      <choice name="Custom 2.1x (1512p/2268p)" value="2.1" />
+      <choice name="Custom 2.2x (1584p/2376p)" value="2.2" />
+      <choice name="Custom 2.3x (1656p/2484p)" value="2.3" />
+      <choice name="Custom 2.4x (1728p/2592p)" value="2.4" />
+      <choice name="Custom 2.5x (1800p/2700p)" value="2.5" />
+      <choice name="Custom 2.6x (1872p/2808p)" value="2.6" />
+      <choice name="Custom 2.7x (1944p/2916p)" value="2.7" />
+      <choice name="Custom 2.8x (2016p/3024p)" value="2.8" />
+      <choice name="Custom 2.9x (2088p/3132p)" value="2.9" />
+      <choice name="Custom 3.0x (2160p/3240p)" value="3.0" />
     </feature>
     <feature name="ASPECT RATIO" value="aspect_ratio" description="Aspect Ratio Auto=16:9">
       <choice name="4:3" value="Fixed4x3" />
@@ -917,36 +915,35 @@
       <choice name="2x (1440p/2160p)" value="2.0" />
       <choice name="3x (2160p/3240p)" value="3.0" />
       <choice name="4x (2880p/4320p)" value="4.0" />
-      <choice name="Custom 0.1x" value="0.1" />
-      <choice name="Custom 0.2x" value="0.2" />
-      <choice name="Custom 0.3x" value="0.3" />
-      <choice name="Custom 0.4x" value="0.4" />
-      <choice name="Custom 0.5x" value="0.5" />
-      <choice name="Custom 0.6x" value="0.6" />
-      <choice name="Custom 0.7x" value="0.7" />
-      <choice name="Custom 0.8x" value="0.8" />
-      <choice name="Custom 0.9x" value="0.9" />
-      <choice name="Custom 1.0x" value="1.0" />
-      <choice name="Custom 1.1x" value="1.1" />
-      <choice name="Custom 1.2x" value="1.2" />
-      <choice name="Custom 1.3x" value="1.3" />
-      <choice name="Custom 1.4x" value="1.4" />
-      <choice name="Custom 1.5x" value="1.5" />
-      <choice name="Custom 1.6x" value="1.6" />
-      <choice name="Custom 1.7x" value="1.7" />
-      <choice name="Custom 1.8x" value="1.8" />
-      <choice name="Custom 1.9x" value="1.9" />
-      <choice name="Custom 2.0x" value="2.0" />
-      <choice name="Custom 2.1x" value="2.1" />
-      <choice name="Custom 2.2x" value="2.2" />
-      <choice name="Custom 2.3x" value="2.3" />
-      <choice name="Custom 2.4x" value="2.4" />
-      <choice name="Custom 2.5x" value="2.5" />
-      <choice name="Custom 2.6x" value="2.6" />
-      <choice name="Custom 2.7x" value="2.7" />
-      <choice name="Custom 2.8x" value="2.8" />
-      <choice name="Custom 2.9x" value="2.9" />
-      <choice name="Custom 3.0x" value="3.0" />
+      <choice name="Custom 0.2x (144p/216p)" value="0.2" />
+      <choice name="Custom 0.3x (216p/324p)" value="0.3" />
+      <choice name="Custom 0.4x (288p/432p)" value="0.4" />
+      <choice name="Custom 0.5x (360p/540p)" value="0.5" />
+      <choice name="Custom 0.6x (432p/648p)" value="0.6" />
+      <choice name="Custom 0.7x (504p/756p)" value="0.7" />
+      <choice name="Custom 0.8x (576p/864p)" value="0.8" />
+      <choice name="Custom 0.9x (648p/972p)" value="0.9" />
+      <choice name="Custom 1.0x (720p/1080p)" value="1.0" />
+      <choice name="Custom 1.1x (792p/1188p)" value="1.1" />
+      <choice name="Custom 1.2x (864p/1296p)" value="1.2" />
+      <choice name="Custom 1.3x (936p/1404p)" value="1.3" />
+      <choice name="Custom 1.4x (1008p/1512p)" value="1.4" />
+      <choice name="Custom 1.5x (1080p/1620p)" value="1.5" />
+      <choice name="Custom 1.6x (1152p/1728p)" value="1.6" />
+      <choice name="Custom 1.7x (1224p/1836p)" value="1.7" />
+      <choice name="Custom 1.8x (1296p/1994p)" value="1.8" />
+      <choice name="Custom 1.9x (1368p/2052p)" value="1.9" />
+      <choice name="Custom 2.0x (1440p/2160p)" value="2.0" />
+      <choice name="Custom 2.1x (1512p/2268p)" value="2.1" />
+      <choice name="Custom 2.2x (1584p/2376p)" value="2.2" />
+      <choice name="Custom 2.3x (1656p/2484p)" value="2.3" />
+      <choice name="Custom 2.4x (1728p/2592p)" value="2.4" />
+      <choice name="Custom 2.5x (1800p/2700p)" value="2.5" />
+      <choice name="Custom 2.6x (1872p/2808p)" value="2.6" />
+      <choice name="Custom 2.7x (1944p/2916p)" value="2.7" />
+      <choice name="Custom 2.8x (2016p/3024p)" value="2.8" />
+      <choice name="Custom 2.9x (2088p/3132p)" value="2.9" />
+      <choice name="Custom 3.0x (2160p/3240p)" value="3.0" />
     </feature>
     <feature name="ASPECT RATIO" value="aspect_ratio" description="Aspect Ratio Auto=16:9">
       <choice name="4:3" value="Fixed4x3" />


### PR DESCRIPTION
Added custom resolutions descriptions for Ryujinx. 

Removed Custom 0.1x (72p/108p) 

since it's to small and not even usable on a CRT