### PR TITLE
make xbox series x controllers usable with ryujinx

### DIFF
--- a/system/configs/emulationstation/es_features_switch.cfg
+++ b/system/configs/emulationstation/es_features_switch.cfg
@@ -6,7 +6,7 @@
     <sharedFeature value="videomode" />
     <sharedFeature value="hud" />
     <sharedFeature value="hud_corner" />
-    <feature name="AUTO CONTROLLER CONFIG" value="yuzu_auto_controller_config" description="Auto Controller Configuration Auto=On ">
+    <feature name="AUTO CONTROLLER CONFIG" value="yuzu_auto_controller_config" description="Auto Controller Configuration Auto=On. Turn it Off to use Xbox Series X Controllers.">
       <choice name="Off" value="0" />
       <choice name="On" value="1" />
     </feature>

--- a/system/configs/emulationstation/es_features_switch.cfg
+++ b/system/configs/emulationstation/es_features_switch.cfg
@@ -6,7 +6,7 @@
     <sharedFeature value="videomode" />
     <sharedFeature value="hud" />
     <sharedFeature value="hud_corner" />
-    <feature name="AUTO CONTROLLER CONFIG" value="yuzu_auto_controller_config" description="Auto Controller Configuration Auto=On. Turn it Off to use Xbox Series X Controllers.">
+    <feature name="AUTO CONTROLLER CONFIG" value="yuzu_auto_controller_config" description="Auto Controller Configuration Auto=On ">
       <choice name="Off" value="0" />
       <choice name="On" value="1" />
     </feature>
@@ -454,7 +454,7 @@
     <sharedFeature value="videomode" />
     <sharedFeature value="hud" />
     <sharedFeature value="hud_corner" />
-    <feature name="AUTO CONTROLLER CONFIG" value="ryu_auto_controller_config" description="Auto Controller Configuration Auto=On ">
+    <feature name="AUTO CONTROLLER CONFIG" value="ryu_auto_controller_config" description="Auto Controller Configuration Auto=On. Turn it Off to use Xbox Series X Controllers.">
       <choice name="Off" value="0" />
       <choice name="On" value="1" />
     </feature>
@@ -650,7 +650,7 @@
     <sharedFeature value="videomode" />
     <sharedFeature value="hud" />
     <sharedFeature value="hud_corner" />
-    <feature name="AUTO CONTROLLER CONFIG" value="ryu_auto_controller_config" description="Auto Controller Configuration Auto=On ">
+    <feature name="AUTO CONTROLLER CONFIG" value="ryu_auto_controller_config" description="Auto Controller Configuration Auto=On. Turn it Off to use Xbox Series X Controllers.">
       <choice name="Off" value="0" />
       <choice name="On" value="1" />
     </feature>
@@ -846,7 +846,7 @@
     <sharedFeature value="videomode" />
     <sharedFeature value="hud" />
     <sharedFeature value="hud_corner" />
-    <feature name="AUTO CONTROLLER CONFIG" value="ryu_auto_controller_config" description="Auto Controller Configuration Auto=On ">
+    <feature name="AUTO CONTROLLER CONFIG" value="ryu_auto_controller_config" description="Auto Controller Configuration Auto=On. Turn it Off to use Xbox Series X Controllers.">
       <choice name="Off" value="0" />
       <choice name="On" value="1" />
     </feature>

--- a/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
+++ b/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
@@ -269,6 +269,12 @@ class RyujinxMainlineGenerator(Generator):
 
         if ((system.isOptSet('ryu_auto_controller_config') and not (system.config["ryu_auto_controller_config"] == "0")) or not system.isOptSet('ryu_auto_controller_config')):
             
+            # make sure that libSDL2.so is restored (because when using Xbox series X, it has to be renamed in libSDL2.so-configgen
+            filename_sdl2 = os.environ["PYSDL2_DLL_PATH"] + "libSDL2.so"
+            filename_sdl2_configgen = filename_sdl2 + "-configgen"
+            if not os.path.exists(filename_sdl2):
+                os.replace(filename_sdl2_configgen, filename_sdl2)
+
             filename = "/userdata/system/switch/configgen/debugcontrollers.txt"
             if os.path.exists(filename):
                 file = open(filename, 'r')
@@ -645,6 +651,16 @@ class RyujinxMainlineGenerator(Generator):
             
             data['input_config'] = input_config
 
+        # if we turn the auto_control_config off, then it's better to avoid conflicts with the sdl2 coming from ryujinx (which completely messes up xbox series x controllers with both bluetooth and dongle
+        try:
+            if system.config["ryu_auto_controller_config"] == "0":
+                filename_sdl2 = os.environ["PYSDL2_DLL_PATH"] + "libSDL2.so"
+                filename_sdl2_configgen = filename_sdl2 + "-configgen"
+                if os.path.exists(filename_sdl2):
+                    os.replace(filename_sdl2, filename_sdl2_configgen)
+        except:
+            pass
+        
         #Resolution Scale
         if system.isOptSet('ryu_resolution_scale'):
             if system.config["ryu_resolution_scale"] in {'1.0', '2.0', '3.0', '4.0', 1.0, 2.0, 3.0, 4.0}:


### PR DESCRIPTION
I have a hard time using my xbox series x controllers on Ryujinx:

1. Via bluetooth, in Ryujinx, the controller shows but doesn't register any input
2. With the dedicated dongle, the mapping is messed up: the switch A button is on the west button, I cannot register the south button,...

Once you delete the /userdata/system/switch/extra/ryujinxavalonia/libSDL2.so (following a suggestion from discord), the xbox series x controller starts working perfectly. The only side effect I noticed is that you can't autoconfigure the controllers: you have to do that manually, either by pressing F1>Applications>Ryujinx, or in game with "Alt+Enter" to leave full-screen. The controllers configuration is then saved.
I tested with 4 xbox series x controllers connected through the dedicated dongle + 2 official ds4v2 connected via bluetooth and it worked well.
This PR tests if the user want the automatic configuration: then it keeps the libSDL2.so. Otherwise, it renames the libSDL2.so in libSDL2.so-configgen
Hopefully, this could save a lot of time for some users.
 